### PR TITLE
Add build_info.txt in Jenkins build. New view build_info.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
+django/webapps/build_info.txt
 django/webapps/webapps/local_settings.py

--- a/django/webapps/webapps/settings.py
+++ b/django/webapps/webapps/settings.py
@@ -122,9 +122,22 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
+
 # Import local settings, if defined.
 # Local settings can be used to overwrite values in development and testing environments.
 try:
-  from .local_settings import *
+    from .local_settings import *
 except ImportError:
-  pass
+    pass
+
+
+# Set build info from text file, if defined.
+BUILD_INFO = 'Build information not available'
+try:
+    build_info_file = os.path.join(BASE_DIR, 'build_info.txt')
+    reader = open(build_info_file, 'r')
+    BUILD_INFO = reader.readline()
+    reader.close()
+except:
+    print(build_info_file + ' not found')
+    pass

--- a/django/webapps/webapps/urls.py
+++ b/django/webapps/webapps/urls.py
@@ -6,8 +6,11 @@
 # :license: MIT
 from django.contrib import admin
 from django.urls import path, include
+from django.conf.urls import url
+from . import views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('portalapi/', include('portalapi.urls')),
+    url('build_info', views.build_info),
 ]

--- a/django/webapps/webapps/views.py
+++ b/django/webapps/webapps/views.py
@@ -1,0 +1,8 @@
+from django.http import HttpResponse
+from django.conf import settings
+
+def build_info(request):
+    """
+    Return build information.
+    """
+    return HttpResponse(settings.BUILD_INFO)

--- a/nginx/Jenkinsfile
+++ b/nginx/Jenkinsfile
@@ -35,7 +35,16 @@ node {
     echo sh(returnStdout: true, script: 'env')
   }
 
- /*
+  /*
+   * Write build_info.txt file.
+   * Add timestamp from environment variable BUILD_TIMESTAMP. Requires Build Timestamp plugin installed in Jenkins.
+   * Add Git commit info from git_commit_hash.
+   */
+  stage('Add build_info.txt') {
+    sh "echo ${BUILD_TIMESTAMP} ${git_commit_hash} > django/webapps/build_info.txt"
+  }
+
+  /*
    * Build and tag Docker image
    */
   stage('Build and tag Docker image') {


### PR DESCRIPTION
Added mechanism to easily check which build version of proxy API is running.
File _build_info.txt_ is created during Jenkins build. File contents is timestamp and Git commit hash.
In Django application added new view _build_info_, which displays build_info.txt contents.