### PR TITLE
Cscttv 600

### DIFF
--- a/django/webapps/portalapi/tests.py
+++ b/django/webapps/portalapi/tests.py
@@ -16,7 +16,7 @@ class ElasticsearchProxyViewTests(SimpleTestCase):
         """When request HTTP method is GET it is forwarded to Elasticsearch."""
 
         # In unit test, instead of Elasticsearch, forward request to internal view "ping", which responds with HTTP status 200.
-        search_url = self.base_url + "/ping/"
+        search_url = self.base_url + "ping/"
         response = self.client.get(search_url)
         self.assertEquals(response.status_code,
                           HTTPStatus.OK.value)

--- a/django/webapps/portalapi/tests.py
+++ b/django/webapps/portalapi/tests.py
@@ -12,6 +12,16 @@ from http import HTTPStatus
 class ElasticsearchProxyViewTests(SimpleTestCase):
     base_url = '/portalapi/'
 
+    def test_get_request_is_allowed(self):
+        """When request HTTP method is GET it is forwarded to Elasticsearch."""
+
+        # In unit test, instead of Elasticsearch, forward request to internal view "ping", which responds with HTTP status 200.
+        search_url = self.base_url + "/ping/"
+        response = self.client.get(search_url)
+        self.assertEquals(response.status_code,
+                          HTTPStatus.OK.value)
+
+
     def test_post_request_not_allowed_without_search(self):
         """When request HTTP method is POST and request URL does not contain '_search', it is rejected with status code 405 Method Not Allowed"""
         search_url = self.base_url + "/publication,person/"

--- a/django/webapps/portalapi/urls.py
+++ b/django/webapps/portalapi/urls.py
@@ -4,11 +4,11 @@
 #
 # :author: CSC - IT Center for Science Ltd., Espoo Finland servicedesk@csc.fi
 # :license: MIT
-from django.urls import path
 from django.conf.urls import url
 from . import views
 
 urlpatterns = [
+    url('ping', views.ping, name='ping'),
     url(r'^(?P<path>.*)$',
         views.ElasticsearchProxyView.as_view(), name='elasticsearch-proxy-view'),
 ]

--- a/django/webapps/portalapi/views.py
+++ b/django/webapps/portalapi/views.py
@@ -52,3 +52,11 @@ class ElasticsearchProxyView(ProxyView):
 
     # The URL of the proxied server.
     upstream = settings.ELASTICSEARCH_HOST
+
+
+def ping(request):
+    """
+    Responds to request with status 200 OK.
+    Used in unit test to simulate successfull response from Elasticsearch.
+    """
+    return HttpResponse(status=HTTPStatus.OK.value)


### PR DESCRIPTION
Added view 'portalapi/ping', which responds to request with HTTP status 200 OK.
That view is used in unit test for testing successful proxying of request, the view 'portalapi/ping' simulates response from Elasticsearch. 